### PR TITLE
Implement pCloud MCP gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# pcloud-mcp
+# pCloud MCP Gateway
+
+This project provides a simple REST API to interact with [pCloud](https://www.pcloud.com/) using only an access token. It exposes endpoints to list, upload, download and delete files through a minimal server acting as a My Cloud Provider (MCP).
+
+## Architecture
+
+- **FastAPI** web framework (Python)
+- **Requests** library for HTTP calls to pCloud
+- Access token provided via the `PCLOUD_TOKEN` environment variable
+- No persistent storage of credentials
+
+## Installation
+
+1. Clone ce dépôt puis créez éventuellement un environnement virtuel :
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Installez les dépendances :
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Exportez votre jeton d'accès pCloud :
+   ```bash
+   export PCLOUD_TOKEN="<votre_token>"
+   ```
+4. Lancez le serveur :
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+## Endpoints
+
+### `GET /files`
+List files in a pCloud path.
+- **Query:** `path` (default: `/`)
+- **Response:** JSON listing from pCloud
+
+### `POST /upload`
+Upload a file.
+- **Query:** `path` target folder (default: `/`)
+- **Body:** multipart form field `upload` with file content
+- **Response:** JSON from pCloud
+
+### `GET /download`
+Download a file.
+- **Query:** `path` file path
+- **Response:** file stream
+
+### `DELETE /delete`
+Delete a file.
+- **Query:** `path` file path
+- **Response:** JSON from pCloud
+
+## Example API Call
+
+```bash
+curl -X GET "http://localhost:8000/files?path=/" -H "accept: application/json"
+```
+
+## Notes
+
+Ensure the `PCLOUD_TOKEN` variable is kept secure (for example, load it from a safe store or environment configuration tool). The server does not persist the token on disk.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI, HTTPException, UploadFile, File
+from fastapi.responses import StreamingResponse
+import tempfile
+import os
+from . import pcloud_client
+
+app = FastAPI(title="pCloud MCP Gateway")
+
+@app.get("/files")
+def list_files(path: str = "/"):
+    """List files at a given pCloud path."""
+    try:
+        return pcloud_client.list_files(path)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/upload")
+def upload_file(path: str = "/", upload: UploadFile = File(...)):
+    """Upload a file to pCloud."""
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(upload.file.read())
+            tmp_path = tmp.name
+        res = pcloud_client.upload_file(path, tmp_path)
+        os.remove(tmp_path)
+        return res
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/download")
+def download_file(path: str):
+    """Download a file from pCloud."""
+    try:
+        content = pcloud_client.download_file(path)
+        return StreamingResponse(iter([content]), media_type="application/octet-stream")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.delete("/delete")
+def delete_file(path: str):
+    """Delete a file from pCloud."""
+    try:
+        return pcloud_client.delete_file(path)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/pcloud_client.py
+++ b/app/pcloud_client.py
@@ -1,0 +1,40 @@
+import os
+import requests
+from typing import List
+
+API_BASE = "https://api.pcloud.com"
+
+def get_token() -> str:
+    token = os.getenv("PCLOUD_TOKEN")
+    if not token:
+        raise RuntimeError("PCLOUD_TOKEN environment variable not set")
+    return token
+
+def list_files(path: str) -> dict:
+    token = get_token()
+    params = {"path": path, "access_token": token}
+    resp = requests.get(f"{API_BASE}/listfolder", params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+def upload_file(path: str, file_path: str) -> dict:
+    token = get_token()
+    params = {"path": path, "access_token": token}
+    files = {"file": open(file_path, "rb")}
+    resp = requests.post(f"{API_BASE}/uploadfile", params=params, files=files)
+    resp.raise_for_status()
+    return resp.json()
+
+def download_file(path: str) -> bytes:
+    token = get_token()
+    params = {"path": path, "access_token": token}
+    resp = requests.get(f"{API_BASE}/getfile", params=params, stream=True)
+    resp.raise_for_status()
+    return resp.content
+
+def delete_file(path: str) -> dict:
+    token = get_token()
+    params = {"path": path, "access_token": token}
+    resp = requests.post(f"{API_BASE}/deletefile", params=params)
+    resp.raise_for_status()
+    return resp.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+requests


### PR DESCRIPTION
## Summary
- add FastAPI server to expose REST endpoints
- implement pCloud client using access token
- document usage and API endpoints
- provide requirements
- clarify installation steps

## Testing
- `python3 -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_b_6867f931a88083279558268230ade713