### PR TITLE
Add MCP gateway server for pCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# pcloud-mcp
+# pCloud MCP Gateway
+
+This project provides a lightweight REST server acting as a Model Context Protocol (MCP) gateway for [pCloud](https://www.pcloud.com/). It allows listing, uploading, downloading and deleting files from a pCloud account using only an **access token**.
+
+## Requirements
+
+- Node.js 20+
+- A valid `PCLOUD_TOKEN` from pCloud
+
+## Configuration
+
+Set the environment variable `PCLOUD_TOKEN` with your pCloud access token. Optionally, set `PORT` to change the listening port (default is `3000`).
+
+```
+export PCLOUD_TOKEN=your_token_here
+node server.js
+```
+
+## Endpoints
+
+### `GET /files`
+List files in the root folder of your pCloud storage.
+
+### `POST /files`
+Upload a file. The request body must be JSON:
+
+```json
+{
+  "path": "/folder/name.txt",
+  "content": "base64-encoded content"
+}
+```
+
+### `GET /download?path=/folder/name.txt`
+Download a file. Returns the raw file bytes.
+
+### `DELETE /files?path=/folder/name.txt`
+Delete a file from pCloud.
+
+Each operation uses the `PCLOUD_TOKEN` for authentication when calling the pCloud API.
+
+## Example
+
+```
+# List files
+curl http://localhost:3000/files
+
+# Upload a text file
+curl -X POST http://localhost:3000/files \
+  -H "Content-Type: application/json" \
+  -d '{"path":"/hello.txt","content":"SGVsbG8gd29ybGQh"}'
+
+# Download a file
+curl "http://localhost:3000/download?path=/hello.txt" -o hello.txt
+
+# Delete a file
+curl -X DELETE "http://localhost:3000/files?path=/hello.txt"
+```
+
+## Notes on Security
+
+The server expects the access token through an environment variable and never stores it on disk. Ensure the token is kept secret and the server runs in a trusted environment.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pcloud-mcp",
+  "version": "1.0.0",
+  "description": "MCP gateway for pCloud",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,129 @@
+const http = require('http');
+const { URL } = require('url');
+
+const PCLOUD_TOKEN = process.env.PCLOUD_TOKEN;
+if (!PCLOUD_TOKEN) {
+  console.error('Missing PCLOUD_TOKEN environment variable');
+  process.exit(1);
+}
+
+const API_BASE = 'https://api.pcloud.com';
+
+async function pcloudRequest(endpoint, options = {}) {
+  const url = endpoint.includes('http') ? endpoint : `${API_BASE}${endpoint}`;
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status} - ${text}`);
+  }
+  return res;
+}
+
+async function listFiles() {
+  const res = await pcloudRequest(`/listfolder?path=%2F&access_token=${PCLOUD_TOKEN}`);
+  return res.json();
+}
+
+async function uploadFile(path, buffer) {
+  const form = new FormData();
+  const blob = new Blob([buffer]);
+  const filename = path.split('/').pop();
+  form.append('file', blob, filename);
+  const url = `/uploadfile?path=${encodeURIComponent(path)}&access_token=${PCLOUD_TOKEN}`;
+  const res = await pcloudRequest(url, { method: 'POST', body: form });
+  return res.json();
+}
+
+async function getDownloadLink(path) {
+  const res = await pcloudRequest(`/getfilelink?path=${encodeURIComponent(path)}&access_token=${PCLOUD_TOKEN}`);
+  const data = await res.json();
+  if (data.result !== 0) throw new Error(data.error);
+  const host = data.hosts[0];
+  return `https://${host}${data.path}`;
+}
+
+async function downloadFile(path) {
+  const link = await getDownloadLink(path);
+  const res = await pcloudRequest(link);
+  const arrayBuffer = await res.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+async function deleteFile(path) {
+  const res = await pcloudRequest(`/deletefile?path=${encodeURIComponent(path)}&access_token=${PCLOUD_TOKEN}`);
+  return res.json();
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  // enable CORS for convenience
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,DELETE,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  try {
+    if (req.method === 'GET' && url.pathname === '/files') {
+      const data = await listFiles();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    } else if (req.method === 'POST' && url.pathname === '/files') {
+      let body = '';
+      req.on('data', chunk => body += chunk);
+      req.on('end', async () => {
+        try {
+          const { path, content } = JSON.parse(body);
+          if (!path || !content) {
+            res.writeHead(400);
+            res.end('Missing path or content');
+            return;
+          }
+          const buffer = Buffer.from(content, 'base64');
+          const data = await uploadFile(path, buffer);
+          res.writeHead(201, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(data));
+        } catch (err) {
+          res.writeHead(500);
+          res.end(err.toString());
+        }
+      });
+    } else if (req.method === 'GET' && url.pathname === '/download') {
+      const path = url.searchParams.get('path');
+      if (!path) {
+        res.writeHead(400);
+        res.end('Missing path');
+        return;
+      }
+      const fileBuffer = await downloadFile(path);
+      res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+      res.end(fileBuffer);
+    } else if (req.method === 'DELETE' && url.pathname === '/files') {
+      const path = url.searchParams.get('path');
+      if (!path) {
+        res.writeHead(400);
+        res.end('Missing path');
+        return;
+      }
+      const data = await deleteFile(path);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    } else {
+      res.writeHead(404);
+      res.end('Not Found');
+    }
+  } catch (err) {
+    res.writeHead(500);
+    res.end(err.toString());
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- implement a small HTTP server (`server.js`) that proxies file operations to pCloud using an access token
- document usage and REST endpoints in `README.md`
- add `package.json` with start script

## Testing
- `PCLOUD_TOKEN=dummy PORT=0 node server.js`

------
https://chatgpt.com/codex/tasks/task_b_68680907330083278f8ca48bb4288a76